### PR TITLE
Fem 2079 DTG - Removing a media during downloading, can't download the media again.

### DIFF
--- a/Sources/Downloader/DefaultDownloader.swift
+++ b/Sources/Downloader/DefaultDownloader.swift
@@ -125,9 +125,10 @@ extension DefaultDownloader {
     }
     
     func cancel() {
+        // Invalidate the session before canceling, so that no new tast will start
+        self.invalidateSession()
         self.cancelDownloadTasks()
         self.state.value = .cancelled
-        self.invalidateSession()
     }
     
     func invalidateSession() {
@@ -200,11 +201,12 @@ private extension DefaultDownloader {
     
     func cancelDownloadTasks() {
         guard self.activeDownloads.count > 0 else { return }
+        // Remove all items in the queue before canceling the active ones
+        self.downloadItemTasksQueue.purge()
         for (sessionTask, _) in self.activeDownloads {
             sessionTask.cancel()
         }
         self.activeDownloads.removeAll()
-        self.downloadItemTasksQueue.purge()
     }
     
     func setBackgroundURLSession() {


### PR DESCRIPTION
Fixed download status and progress after removing a task.

Changed the order of calls to functions in the DefaultDownloader to invalidate the session before canceling the tasks. Removed the tasks in the queue before canceling the active tasks. Added protection code in the ContentManager, that if we get a progress update after the download has been removed, not to continue.
