### PR TITLE
Adds throttle to DefaultDownloader progress updates

### DIFF
--- a/Sources/Downloader/DefaultDownloader.swift
+++ b/Sources/Downloader/DefaultDownloader.swift
@@ -318,8 +318,10 @@ extension DefaultDownloader: URLSessionDownloadDelegate {
         }
         
         // Forward any previously-throttled download progress
-        self.delegate?.downloader(self, didProgress: throttledBytesWritten)
-        throttledBytesWritten = 0
+        if throttledBytesWritten > 0 {
+            self.delegate?.downloader(self, didProgress: throttledBytesWritten)
+            throttledBytesWritten = 0
+        }
         
         do {
             // if the file exists for some reason, rewrite it.


### PR DESCRIPTION
Added a throttle on `DefaultDownloader` download progress updates.

The throttle ensures that the Realm database in't overloaded by write transactions (which used to be initiated for every `DefaultDownloader` progress update). Throttling these database transactions result in greater crash stability, as well as far lower CPU utilisation during downloads.