### PR TITLE
Delegate in protocols

### DIFF
--- a/Sources/API/API.swift
+++ b/Sources/API/API.swift
@@ -19,7 +19,7 @@ public protocol DTGContentManager: class {
     var storagePath: URL { get }
     
     /// Delegate that will receive download events.
-    weak var delegate: ContentManagerDelegate? { get set }
+    var delegate: ContentManagerDelegate? { get set }
     
     /// set log level for viewing logs.
     func setLogLevel(_ logLevel: LogLevel)

--- a/Sources/Downloader/Downloader.swift
+++ b/Sources/Downloader/Downloader.swift
@@ -50,7 +50,7 @@ protocol Downloader: class {
     var sessionIdentifier: String { get }
     
     /// The downloader delegate object.
-    weak var delegate: DownloaderDelegate? { get set }
+    var delegate: DownloaderDelegate? { get set }
     
     /// Background completion handler, can be received from application delegate when woken to background.
     /// Should be invoked when `urlSessionDidFinishEvents` is called.


### PR DESCRIPTION
Delegate in protocols are not set as 'weak' any more. This is set only in the class that implements the protocol.